### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can set your own fields and variables. To do this modify these files:
 
 You can also create plugins to handle your variables, in the directory /modules/ModuleDesigner/plugins
 
-#v1.0 RC Change log:
+# v1.0 RC Change log:
 - Icon added for ModuleDesigner
 - HTML special chars bug fix
 - It is now possible to modify Vtiger Core’s modules


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
